### PR TITLE
Fix Collection URL to allow for multiple CollectionAliases

### DIFF
--- a/nyhvariables.py
+++ b/nyhvariables.py
@@ -3,7 +3,7 @@
 
 def collection_url(alias, title):
 	# Ryan and Chuck, this is where the url is build for the collection URL. Change as necessary
-	return 'https://cdm16694.contentdm.oclc.org/digital/collection/' + alias + '/search/searchterm/' + title + '/field/relatig/mode/exact/conn/and/order/date'
+	return 'https://cdm16694.contentdm.oclc.org/digital/search/collection/' + alias + '/searchterm/' + title + '/field/relatig/mode/exact/conn/and/order/date'
 
 def namespaces():
 	return {


### PR DESCRIPTION
Both formats of the URL work when searching only one Collection Alias, but "search/" needs to be after "digital/" to search across multiple Collection Aliases.